### PR TITLE
fix: AVAudioSession setup + background audio support

### DIFF
--- a/tempo-metronome/Engine/MetronomeEngine.swift
+++ b/tempo-metronome/Engine/MetronomeEngine.swift
@@ -1,5 +1,6 @@
 import AVFAudio
 import Observation
+import UIKit
 
 @Observable
 final class MetronomeEngine {
@@ -47,6 +48,53 @@ final class MetronomeEngine {
 
         engine.attach(playerNode)
         engine.connect(playerNode, to: engine.mainMixerNode, format: format)
+
+        configureAudioSession()
+        observeInterruptions()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Audio Session
+
+    private func configureAudioSession() {
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playback, mode: .default)
+            try session.setActive(true)
+        } catch {
+            // Audio session setup failed — app will still work but may use wrong output
+        }
+    }
+
+    private func observeInterruptions() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleInterruption),
+            name: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance()
+        )
+    }
+
+    @objc private func handleInterruption(_ notification: Notification) {
+        guard let info = notification.userInfo,
+              let typeValue = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else { return }
+
+        switch type {
+        case .began:
+            stop()
+        case .ended:
+            // Only auto-resume if the system says it's okay to do so
+            if let optionsValue = info[AVAudioSessionInterruptionOptionKey] as? UInt,
+               AVAudioSession.InterruptionOptions(rawValue: optionsValue).contains(.shouldResume) {
+                try? AVAudioSession.sharedInstance().setActive(true)
+            }
+        @unknown default:
+            break
+        }
     }
 
     // MARK: - Public API


### PR DESCRIPTION
## Was wurde geändert

- `AVAudioSession` category auf `.playback` gesetzt — Audio spielt jetzt über den Lautsprecher (nicht Ohrhörer) und ignoriert den Stumm-Schalter
- `AVAudioSession.interruptionNotification` wird beobachtet — bei Telefonanruf oder Siri stoppt das Metronom sauber
- Background Modes Capability in Xcode hinzugefügt (`UIBackgroundModes: audio`) — App spielt weiter wenn der Bildschirm gesperrt ist

## Wie testen

1. **Lautsprecher:** App starten → Play → Audio kommt aus dem Bottom-Speaker, nicht dem Ohrhörer
2. **Stumm-Schalter:** Gerät stumm schalten → Metronom spielt trotzdem
3. **Bildschirm sperren:** Play drücken → Bildschirm sperren → Klick läuft weiter
4. **Unterbrechung:** Play drücken → Anruf annehmen → Metronom stoppt; Anruf beenden → Metronom bleibt gestoppt (kein automatisches Weiterpielen)

## Was du daraus lernen kannst

**AVAudioSession** ist iOS' zentrales Audio-Routing-System. Jede App muss explizit sagen welche Art von Audio sie macht:
- `.playback` = "Ich spiele Musik/Töne, auch bei gesperrtem Bildschirm und Stumm-Schalter"
- `.ambient` = "Hintergrundgeräusch, pausiert bei Anruf, stoppt bei Stumm"
- `.record` = "Ich nehme auf"

Ohne diese Konfiguration nimmt iOS `.soloAmbient` als Default — deshalb spielte das Metronom bisher über den Ohrhörer.

Closes #13, Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio session management to properly handle system audio interruptions. The metronome now pauses when interrupted (such as during incoming calls or other audio playback) and appropriately resumes based on system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->